### PR TITLE
Fix precompiler to work with Handlebars 2.0.0

### DIFF
--- a/lib/barber/javascripts/emblem_precompiler.js
+++ b/lib/barber/javascripts/emblem_precompiler.js
@@ -1,11 +1,12 @@
 var exports = this.exports || {};
+var module = this.module || {exports: null};
 
 var Emblem;
 var self = this;
 
 function require() {
   // ember-template-compiler only requires('handlebars')
-  return Handlebars;
+  return module.exports || Handlebars;
 }
 
 var Barber = {


### PR DESCRIPTION
Added minor backward compatible changes to make barber-emblem work with new Handlebars.
